### PR TITLE
Onehat

### DIFF
--- a/src/Whmcs.php
+++ b/src/Whmcs.php
@@ -22,8 +22,9 @@ class Whmcs
     }
     return self::$CLIENT;
   }
-  public function execute($action, $parameters=[])
+  public function execute($action, $args=[])
   {
+    $parameters = $args[0];
     $class = $this;
     $tapHandler = Middleware::tap(function(RequestInterface $request) use($class){
       $class->setRequest($request);

--- a/src/Whmcs.php
+++ b/src/Whmcs.php
@@ -24,7 +24,7 @@ class Whmcs
   }
   public function execute($action, $args=[])
   {
-    $parameters = $args[0];
+    $parameters = isset($args[0]) ? $args[0] : [];
     $class = $this;
     $tapHandler = Middleware::tap(function(RequestInterface $request) use($class){
       $class->setRequest($request);


### PR DESCRIPTION
Magic method __call was burying the supplied parameters into an array. They were then staying that way, and not getting passed to the execute method correctly. This fix un-buries them.