### PR TITLE
Check response result key existed to check success

### DIFF
--- a/src/WhmcsResponse.php
+++ b/src/WhmcsResponse.php
@@ -13,7 +13,7 @@ class WhmcsResponse implements ArrayAccess
   }
   public function isSuccess()
   {
-    return $this->result == 'success';
+    return isset($this->result) && $this->result == 'success';
   }
   public function __get($var)
   {


### PR DESCRIPTION
Requested get Invoice api call, then I got:

[14-Nov-2019 12:04:34 Africa/Tripoli] PHP Notice: Undefined index: result in /Path/to/vendor/gufy/whmcs-php/src/WhmcsResponse.php on line 20

this update should fix this issue